### PR TITLE
Fix to allow it to work with controllers

### DIFF
--- a/SeamothStorageAccess/Main.cs
+++ b/SeamothStorageAccess/Main.cs
@@ -22,7 +22,7 @@ namespace SeamothStorageAccess
             var slotTypes = typeof(CraftData).GetField("slotTypes", BindingFlags.NonPublic | BindingFlags.Static)
                             .GetValue(null) as Dictionary<TechType, QuickSlotType>;
 
-            slotTypes[TechType.VehicleStorageModule] = QuickSlotType.Instant;
+            slotTypes[TechType.VehicleStorageModule] = QuickSlotType.Selectable;
 
             Console.WriteLine("[SeamothStorageAccess] Successfully patched.");
         }


### PR DESCRIPTION
Controllers only support Seamoth/Prawn QuickSlotTypes of Selectable, SelectableChargable, and Passive.  All other types should only be used for the Cyclops.